### PR TITLE
chore(ci): make local renovate dry-run reach the update phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,21 @@ ci:
 readme:
 	$(DOCKER_RUN) $(BUN_IMAGE) sh -lc "bun install --ignore-scripts && bun .github/scripts/readme-generator.ts"
 
+# Pass DOCKERHUB_USERNAME/DOCKERHUB_TOKEN so config.js authenticates Docker Hub
+# lookups (otherwise the dry-run aborts on 429 rate limits before the update
+# phase) and GITHUB_COM_TOKEN for github-tags/release-notes lookups.
+# extends is kept: config:recommended and :dependencyDashboard are internal
+# presets, resolved offline — local run matches production config.
 renovate-test:
 	docker run --rm \
   	-u "0:0" \
   	-e LOG_LEVEL=$(RENOVATE_LOG_LEVEL) \
+  	-e DOCKERHUB_USERNAME \
+  	-e DOCKERHUB_TOKEN \
+  	-e GITHUB_COM_TOKEN \
   	-v "$(PWD)":/tmp/app \
   	--entrypoint bash \
-  	$(RENOVATE_IMAGE) -lc "set -eo pipefail; cp -a /tmp/app /usr/src; cd /usr/src/app; jq 'del(.extends)' /tmp/app/renovate.json >/usr/src/app/renovate.json; renovate --platform=local --dry-run=full"
+  	$(RENOVATE_IMAGE) -lc "set -eo pipefail; cp -a /tmp/app /usr/src; cd /usr/src/app; renovate --platform=local --dry-run=full"
 
 bun-shell:
 	docker run --rm -it -v $(PWD):/app -w /app $(BUN_IMAGE) bash

--- a/config.js
+++ b/config.js
@@ -1,22 +1,25 @@
+const hostRules = [
+  {
+    matchHost: "docker.io",
+    concurrentRequestLimit: 2,
+  },
+];
+
+// Only add authenticated Docker Hub rules when credentials are provided,
+// otherwise Renovate emits "should be a string" config warnings.
+if (process.env.DOCKERHUB_USERNAME && process.env.DOCKERHUB_TOKEN) {
+  for (const matchHost of ["index.docker.io", "hub.docker.com"]) {
+    hostRules.unshift({
+      hostType: "docker",
+      matchHost,
+      username: process.env.DOCKERHUB_USERNAME,
+      password: process.env.DOCKERHUB_TOKEN,
+    });
+  }
+}
+
 export default {
   allowedCommands: [],
-  redisUrl: process.env.RENOVATE_REDIS_URL,
-  hostRules: [
-    {
-      hostType: "docker",
-      matchHost: "index.docker.io",
-      username: process.env.DOCKERHUB_USERNAME,
-      password: process.env.DOCKERHUB_TOKEN,
-    },
-    {
-      hostType: "docker",
-      matchHost: "hub.docker.com",
-      username: process.env.DOCKERHUB_USERNAME,
-      password: process.env.DOCKERHUB_TOKEN,
-    },
-    {
-      matchHost: "docker.io",
-      concurrentRequestLimit: 2,
-    },
-  ],
+  ...(process.env.RENOVATE_REDIS_URL ? { redisUrl: process.env.RENOVATE_REDIS_URL } : {}),
+  hostRules,
 };

--- a/openspec/changes/fix-renovate-automerge/tasks.md
+++ b/openspec/changes/fix-renovate-automerge/tasks.md
@@ -33,8 +33,8 @@
 ## 5. Validation end-to-end
 
 - [x] 5.1 Run `make test` and `make renovate-test` locally → 97 pass / 0 fail, lint clean, renovate config valid (only preexisting env warnings)
-- [ ] 5.2 Commit and merge this change (conventional commit, e.g. `fix(ci): restore renovate automerge chain`)
+- [x] 5.2 Commit and merge this change → PR #422, auto-merged alone via the new ruleset (`ci` green → squash-merge, zero clicks) — first real proof of Bug 3 fix
 - [ ] 5.3 Wait for / force the next Renovate PR (tick a checkbox on the Dependency Dashboard if needed)
 - [ ] 5.4 Verify on that PR: bump commit present → `ci` check runs on it → PR not "edited/blocked" on dashboard → auto-merge enabled → PR merges alone when green
 - [ ] 5.5 Verify README freshness path post-ruleset: bump commit on next Renovate PR includes regenerated README (weekly `readme-generator.yml` deleted)
-- [ ] 5.6 Verify the Dependency Dashboard shows no "rate-limited" section
+- [x] 5.6 Verify the Dependency Dashboard shows no "rate-limited" section → clean post-merge; new `bun`/`github-actions` managers detected (8 npm deps + checkout v6); only `typescript v6` major in Pending Approval (manual by design)


### PR DESCRIPTION
## What

- **Makefile**: forward `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` / `GITHUB_COM_TOKEN` into the renovate container. Without credentials, Docker Hub lookups 429 and the dry-run aborts before the update phase — so `make renovate-test` only ever validated config and extraction. With credentials exported it now reaches branch/PR computation. Without them, behavior is unchanged (no regression).
- **Makefile**: stop stripping `extends` (`jq del`) — `config:recommended` and `:dependencyDashboard` are internal presets resolved offline, so the local run now matches the production config.
- **config.js**: include the Docker Hub hostRules and `redisUrl` only when their env vars are set — removes the 5 `Configuration Error: ... should be a string` warnings from every run.
- **openspec**: tick verified tasks (5.2 PR #422 auto-merged alone, 5.6 dashboard clean) for `fix-renovate-automerge`.

## Validation

- `make renovate-test`: 0 config warnings (was 5), extraction OK
- `make test`: unaffected (no app changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)