### PR TITLE
chore: simplify gitignore patterns and trim claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,11 +13,5 @@
         ]
       }
     ]
-  },
-  "enabledPlugins": {
-    "code-simplifier@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true,
-    "explanatory-output-style@claude-plugins-official": true
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,8 @@ app.png
 
 .cursorrules
 
-# >>> sdd-managed/openspec (toolbox)
-.claude/skills/openspec-*/
+.claude/skills/openspec*
 .claude/commands/opsx/
-.codex/skills/openspec-*/
+.codex/skills/openspec*/
 openspec/config.yaml
-# <<< sdd-managed/openspec (toolbox)
 .toolbox.yaml


### PR DESCRIPTION
## What

- `.gitignore`: collapse the openspec skill patterns (`openspec-*/` → `openspec*`), drop the sdd-managed block markers
- `.claude/settings.json`: remove the `enabledPlugins` block (plugins managed locally)

## Notes

Checked for tracked files matching the ignore patterns (`git ls-files -i -c --exclude-standard`): none — everything ignored was already untracked, no `git rm --cached` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)