### PR TITLE
chore(deps): move typescript to devDependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,8 +14,6 @@
         "@types/bun": "^1.3.14",
         "@types/node": "^25.9.1",
         "ajv": "^8.20.0",
-      },
-      "peerDependencies": {
         "typescript": "^5.9.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -12,14 +12,12 @@
     "@biomejs/biome": "^2.4.16",
     "@types/bun": "^1.3.14",
     "@types/node": "^25.9.1",
-    "ajv": "^8.20.0"
+    "ajv": "^8.20.0",
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "@runtipi/common": "^1.1.3",
     "bun": "^1.3.14",
     "zod-validation-error": "^5.0.0"
-  },
-  "peerDependencies": {
-    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Why

`typescript` sat in `peerDependencies` — semantically wrong for a standalone (non-library) repo, and it broke Renovate's major update: peer deps get `rangeStrategy: widen`, so PR #425 only widened the range to `^5.9.3 || ^6.0.0` without bumping the locked version.

## What

- Move `typescript` to `devDependencies` (same range `^5.9.3`)
- Regenerate `bun.lock`

Next Renovate run will propose a real `typescript 6` major (Pending Approval on the dashboard, as majors are gated).

## Validation

`make test`: pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)