### PR TITLE
fix(types): make tsc --noEmit pass on typescript 6

### DIFF
--- a/apps/__tests__/apps.test.ts
+++ b/apps/__tests__/apps.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 import { parseComposeJson } from "@runtipi/common/schemas";
-import Ajv2020 from "ajv/dist/2020.js";
+import { Ajv2020 } from "ajv/dist/2020.js";
 import draft7MetaSchema from "ajv/dist/refs/json-schema-draft-07.json" with { type: "json" };
 
 interface AppConfig {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,9 @@
     "module": "NodeNext",
     "outDir": "dist",
     "sourceMap": true,
-    "lib": ["es2022"]
+    "lib": ["es2022"],
+    /* TypeScript 6 no longer auto-includes node_modules/@types */
+    "types": ["bun", "node"]
   },
   "include": ["apps/**/*.ts"]
 }


### PR DESCRIPTION
## What

Post-#427 (typescript v6) check: `bunx tsc --noEmit` failed with ~10 errors.

- **tsconfig.json**: add `"types": ["bun", "node"]` — TypeScript 6 no longer auto-includes `node_modules/@types`, so `process`/`console` and Bun globals were unresolved
- **apps/__tests__/apps.test.ts**: `import { Ajv2020 }` (named) instead of default import — the `TS2351: not constructable` CJS-interop error existed with TS5 too, it just never surfaced because `tsc` is not part of CI

## Validation

- `bunx tsc --noEmit`: clean
- `make test`: 97 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)