### PR TITLE
fix(ci): push renovate tipi_version bump with PAT so auto-merge works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  # Dispatched by update-tipi-version.yml after pushing the bump commit:
-  # GITHUB_TOKEN pushes don't trigger pull_request events, but they can
-  # trigger workflow_dispatch, so CI still runs on the bump commit.
-  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/update-tipi-version.yml
+++ b/.github/workflows/update-tipi-version.yml
@@ -39,12 +39,18 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && steps.pr.outputs.head_ref || github.event.pull_request.head.ref }}
           repository: ${{ github.event_name == 'workflow_dispatch' && github.repository || github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Push the bump commit with a PAT, not GITHUB_TOKEN. GITHUB_TOKEN pushes
+          # don't fire pull_request events, so CI never reports a PR-linked `ci`
+          # check and the required-status-check gate stays unsatisfied (PR BLOCKED).
+          # A PAT push fires `synchronize`, so ci.yml runs natively and its check is
+          # linked to the PR. The PAT owner is not renovate[bot], so the resulting
+          # synchronize re-run of THIS workflow is skipped by the actor gate above.
+          token: ${{ secrets.BUMP_PAT }}
 
       - name: Setup git remote
         run: |
           repo=${{ github.event_name == 'workflow_dispatch' && github.repository || github.event.pull_request.head.repo.full_name }}
-          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${repo}.git"
+          git remote set-url origin "https://x-access-token:${{ secrets.BUMP_PAT }}@github.com/${repo}.git"
 
       - name: Read BUN_IMAGE from Makefile
         id: bun
@@ -108,12 +114,20 @@ jobs:
             echo "pushed=true" >> $GITHUB_OUTPUT
           fi
 
-      # Pushes made with GITHUB_TOKEN never trigger other workflows (anti-recursion),
-      # but GITHUB_TOKEN CAN trigger workflow_dispatch: explicitly run CI on the bump
-      # commit so the PR head carries the required `ci` status check.
-      - name: Trigger CI on bump commit
+      # The bump push fires a `synchronize` event, so ci.yml runs natively and its
+      # check is linked to the PR head — no manual workflow_dispatch needed.
+      # That same push disables the native auto-merge Renovate armed at PR creation,
+      # so re-arm it here for automerge-labelled PRs. GitHub then merges (squash)
+      # once the required `ci` check goes green. GITHUB_TOKEN suffices (PR write).
+      - name: Re-enable auto-merge on automerge PRs
         if: steps.commit.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_REF: ${{ github.event_name == 'workflow_dispatch' && steps.pr.outputs.head_ref || github.event.pull_request.head.ref }}
-        run: gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_REF"
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+        run: |
+          if gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+               --jq '.labels[].name' | grep -qx 'automerge'; then
+            gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
+          else
+            echo "PR #$PR_NUMBER has no 'automerge' label; skipping auto-merge."
+          fi


### PR DESCRIPTION
## Problema

Le PR Renovate restano `BLOCKED` e non si auto-mergiano (es. #429). Causa radice unica nel workflow `update-tipi-version.yml`, che pusha il commit di bump `tipi_version` con `GITHUB_TOKEN`:

1. **CI mai collegata alla PR** — i push con `GITHUB_TOKEN` non generano l'evento `pull_request`, quindi `ci.yml` non gira sull'head. Il workaround via `workflow_dispatch` produce un check **non collegato** alla PR (`statusCheckRollup: null` sull'head). Il ruleset `main-require-ci` richiede il check `ci` → mai soddisfatto → PR **BLOCKED** permanente.
2. **Auto-merge disarmato** — il push del bump disattiva l'auto-merge nativo che Renovate aveva armato alla creazione; nessuno lo ri-arma.

## Fix

- Push del bump con `secrets.BUMP_PAT` → genera `synchronize` → `ci.yml` gira nativo e il check è collegato alla PR.
- Il proprietario del PAT ≠ `renovate[bot]`, quindi il `synchronize` non ri-attiva questo workflow (actor gate esistente) → niente loop di bump.
- Ri-arma l'auto-merge (squash) sulle PR con label `automerge` dopo il push.
- Rimosso il trigger `workflow_dispatch` ormai inutile (qui e in `ci.yml`).

## ⚠️ Azione richiesta

Creare un **fine-grained PAT** sul repo con permessi `Contents: write` + `Pull requests: write` e aggiungerlo come secret repo **`BUMP_PAT`**. Senza il secret il workflow fallirà al checkout.

## Note

- `make test` verde (97 pass).
- La #429 attuale non si sblocca da sola nemmeno con questo fix (head senza check collegato): dopo il merge va fatto retry/rebase su Renovate.