### PR TITLE
chore(renovate): disable dependency dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "prConcurrentLimit": 0,
   "branchConcurrentLimit": 0,
   "platformAutomerge": true,
+  "dependencyDashboardApproval": false,
   "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"],
   "extends": ["config:recommended", ":dependencyDashboard"],
   "rebaseWhen": "conflicted",


### PR DESCRIPTION
## Problem

Renovate updates sit under **"Pending Approval"** on the dependency dashboard (#1), needing a manual checkbox tick before each PR is created.

## Root cause

Not a GitHub gate and not this repo's config:
- Ruleset `main-require-ci`: `required_approving_review_count: 0` (no human review) + only the `ci` status check; `allow_auto_merge: true`. Auto-merge already works (PRs #416–429 merged by Renovate).
- `renovate.json` has no `dependencyDashboardApproval`, and all PR/branch limits are `0` (unlimited).

The approval requirement is inherited from the **Mend portal** default. Repo config takes precedence over it.

## Fix

Set `"dependencyDashboardApproval": false` explicitly in `renovate.json`. Renovate will now create branches/PRs without the dashboard checkbox; `ci` runs and the existing `automerge` packageRules merge them.

## Validation

- `make renovate-test` — config valid, resolves `dependencyDashboardApproval: false`, repository finished clean.