### PR TITLE
fix(hermes): use curl for healthcheck (wget absent in image)

### DIFF
--- a/apps/hermes/config.json
+++ b/apps/hermes/config.json
@@ -8,7 +8,7 @@
   "port": 9119,
   "categories": ["ai"],
   "description": "Hermes Agent is a self-hosted AI agent by Nous Research. It runs as a persistent gateway that connects large language models to chat platforms (Telegram, Discord, Slack, WhatsApp) and exposes an OpenAI-compatible API server. A built-in web dashboard lets you manage sessions, memories, skills and configuration from the browser. All state (config, API keys, sessions, memories, skills) lives in a single data directory.",
-  "tipi_version": 1,
+  "tipi_version": 2,
   "version": "v2026.6.5",
   "source": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com",
@@ -16,7 +16,7 @@
   "dynamic_config": true,
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1780942001462,
-  "updated_at": 1780942001462,
+  "updated_at": 1780947170269,
   "min_tipi_version": "4.5.0",
   "form_fields": [
     {

--- a/apps/hermes/docker-compose.json
+++ b/apps/hermes/docker-compose.json
@@ -52,7 +52,7 @@
         }
       ],
       "healthCheck": {
-        "test": "wget --no-verbose --tries=1 --spider http://localhost:9119/ || exit 1",
+        "test": "curl -fsS http://localhost:9119/api/status || exit 1",
         "interval": "30s",
         "timeout": "5s",
         "retries": 5,


### PR DESCRIPTION
## Problem
The `nousresearch/hermes-agent` image ships `curl` but **not** `wget`. The current healthcheck uses `wget`, so it always exits 127 and the container stays permanently `unhealthy` (verified on a live instance: 12 consecutive failures, `wget: not found`).

## Fix
- `docker-compose.json`: healthcheck changed from `wget --spider http://localhost:9119/` to `curl -fsS http://localhost:9119/api/status` (`/api/status` returns 200 JSON, `curl` is present in the image).
- `config.json`: `tipi_version` 1 → 2, `updated_at` bumped.

## Notes
- Dashboard port 9119 (`internalPort`) and API port 8642 (`addPorts`) unchanged — already correct.
- Dashboard backend verified working (200, `auth_required: false`).

## Verification
- `make test` → 104 pass / 0 fail
- `make renovate-test` → OK