### PR TITLE
fix(ci): prevent automerge from merging renovate app PRs before tipi_version bump

### DIFF
--- a/.github/workflows/update-tipi-version.yml
+++ b/.github/workflows/update-tipi-version.yml
@@ -120,7 +120,6 @@ jobs:
       # so re-arm it here for automerge-labelled PRs. GitHub then merges (squash)
       # once the required `ci` check goes green. GITHUB_TOKEN suffices (PR write).
       - name: Re-enable auto-merge on automerge PRs
-        if: steps.commit.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}

--- a/renovate.json
+++ b/renovate.json
@@ -135,6 +135,10 @@
     {
       "matchPackageNames": ["n8nio/n8n", "n8nio/runners"],
       "groupName": "n8n"
+    },
+    {
+      "matchFileNames": ["apps/**"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Problem

In #503 (`update n8n to v2.29.0`) `tipi_version` stayed at 57 across both versions, violating the rule "any change under `apps/**` requires a `tipi_version` bump + `updated_at`".

The mechanism already exists (`update-tipi-version.yml`) but loses a **race condition** against automerge:

| Event | Timestamp |
|---|---|
| PR created (Renovate arms native automerge) | `10:09:11` |
| Bump workflow started | `10:09:18` |
| **PR auto-merged** | `10:09:34` |
| Bump workflow finished (bump pushed) | `10:09:37` |

The `main-require-ci` ruleset requires only the `ci` check (~20s). As soon as it goes green, the automerge Renovate armed at PR creation merges the PR — 3s before the workflow can push the bump. The push lands on an already-closed PR and is lost.

## Fix

1. **`renovate.json`**: new `packageRule` `{ "matchFileNames": ["apps/**"], "automerge": false }` → Renovate no longer arms automerge on app PRs. The `automerge` label stays, so `update-tipi-version.yml` finds it and arms automerge **after** pushing the bump. Non-app PRs (Makefile, github-actions) are unchanged.
2. **`update-tipi-version.yml`**: removed the `if: pushed == 'true'` gate on the "Re-enable auto-merge" step → the workflow arms automerge for every labelled app PR, preventing stalls. If the workflow fails, the PR stays open instead of merging without a bump (fail-safe).

## Verification

- `make renovate-test` ✅ (config valid, `matchFileNames` accepted, v43.x)
- `make test` ✅ (104 pass, lint clean)
- End-to-end: on the next Renovate app PR, the bump commit must appear before the merge and `tipi_version` must be +1 in the final squashed commit.