### PR TITLE
fix(forgejo): let Actions runner auto-register find app.ini

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783630971986,
+  "updated_at": 1783668454394,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -64,6 +64,8 @@
         "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); forgejo forgejo-cli actions register --name tipi-runner --secret \"$$S\" || true"
       ],
       "environment": [
+        { "key": "GITEA_WORK_DIR", "value": "/data" },
+        { "key": "GITEA_CUSTOM", "value": "/data/gitea" },
         { "key": "FORGEJO__database__DB_TYPE", "value": "postgres" },
         { "key": "FORGEJO__database__HOST", "value": "forgejo-db:5432" },
         { "key": "FORGEJO__database__NAME", "value": "forgejo" },


### PR DESCRIPTION
## Problem

Forgejo installs but its Actions runner never comes up. On a live server the one-shot `forgejo-runner-register` container is stuck in a **restart loop**, and because `forgejo-runner` waits on its `service_completed_successfully`, the runner never starts — Forgejo ends up with no working CI/CD.

Container log (looping every ~60s):

```
setting.go:101:MustInstalled() [F] Unable to load config file for a installed Forgejo instance,
you should either use "--config" to set your config file (app.ini), or run "forgejo web" command to install Forgejo.
```

## Root cause

The `forgejo-runner-register` service overrides the image entrypoint with `entrypoint: "/bin/sh"`. The Forgejo image's normal entrypoint is what exports the config-discovery env vars (`GITEA_CUSTOM=/data/gitea`, work dir) before invoking the binary. Bypassing it means `forgejo forgejo-cli actions register` can't locate `app.ini` and fails.

Verified on a running instance:
- `app.ini` exists at container path `/data/gitea/conf/app.ini`.
- The healthy `forgejo` container reports `GITEA_CUSTOM=/data/gitea` (set by its entrypoint); the register container never receives it.
- `forgejo forgejo-cli actions register` is valid and idempotent — only the config path was missing.

## Fix

Add the config-discovery env vars to the `forgejo-runner-register` service, mirroring the working container:

```json
{ "key": "GITEA_WORK_DIR", "value": "/data" },
{ "key": "GITEA_CUSTOM", "value": "/data/gitea" }
```

No other service changes. Bump `tipi_version` 2 -> 3.

## Testing

- `make test` — 120 pass, 0 fail.
- `make renovate-test` — dry-run OK.