### PR TITLE
fix(forgejo): set INSTALL_LOCK so Actions runner can register

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783668454394,
+  "updated_at": 1783683759977,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -16,6 +16,7 @@
         { "key": "FORGEJO__database__NAME", "value": "forgejo" },
         { "key": "FORGEJO__database__USER", "value": "forgejo" },
         { "key": "FORGEJO__database__PASSWD", "value": "${FORGEJO_DB_PASSWORD}" },
+        { "key": "FORGEJO__security__INSTALL_LOCK", "value": "true" },
         { "key": "FORGEJO__actions__ENABLED", "value": "true" },
         { "key": "FORGEJO__server__ROOT_URL", "value": "${APP_PROTOCOL:-http}://${APP_DOMAIN}/" }
       ],
@@ -64,8 +65,6 @@
         "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); forgejo forgejo-cli actions register --name tipi-runner --secret \"$$S\" || true"
       ],
       "environment": [
-        { "key": "GITEA_WORK_DIR", "value": "/data" },
-        { "key": "GITEA_CUSTOM", "value": "/data/gitea" },
         { "key": "FORGEJO__database__DB_TYPE", "value": "postgres" },
         { "key": "FORGEJO__database__HOST", "value": "forgejo-db:5432" },
         { "key": "FORGEJO__database__NAME", "value": "forgejo" },


### PR DESCRIPTION
## Problem

Follow-up to #546, which did **not** fix the issue. On a fresh install the `forgejo-runner-register` container still restart-loops and `forgejo-runner` never starts:

```
setting.go:101:MustInstalled() [F] Unable to load config file for a installed Forgejo instance
```

## Real root cause

A headless, env-configured Forgejo generates `app.ini` with `INSTALL_LOCK = false`. The `forgejo forgejo-cli actions register` command calls `MustInstalled()`, which fails whenever the instance is not locked — regardless of whether `app.ini` is found.

Verified on a fresh install:
- `app.ini` **exists** at `/data/gitea/conf/app.ini` and the path resolves (`GITEA_CUSTOM=/data/gitea` is baked into the image ENV, present even when the entrypoint is overridden).
- `grep` of `app.ini` shows `INSTALL_LOCK = false`.

So #546's `GITEA_WORK_DIR`/`GITEA_CUSTOM` additions were a misdiagnosis: they were redundant and changed nothing.

## Fix

- Add `FORGEJO__security__INSTALL_LOCK=true` to the main `forgejo` service, so the generated `app.ini` marks the instance installed and the CLI can register the runner.
- Remove the redundant `GITEA_WORK_DIR`/`GITEA_CUSTOM` env vars from `forgejo-runner-register` added in #546.
- Bump `tipi_version` 3 -> 4.

## Testing

- `make test` — 120 pass, 0 fail.
- Verified on the live server that the register error corresponds to `INSTALL_LOCK = false` in the generated `app.ini`.