### PR TITLE
fix(forgejo): keep runner-register alive so the runner can start

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 4,
+  "tipi_version": 5,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783683759977,
+  "updated_at": 1783685150475,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -62,7 +62,7 @@
       "entrypoint": "/bin/sh",
       "command": [
         "-c",
-        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); forgejo forgejo-cli actions register --name tipi-runner --secret \"$$S\" || true"
+        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); until forgejo forgejo-cli actions register --name tipi-runner --secret \"$$S\"; do echo 'runner register failed, retrying in 3s'; sleep 3; done; touch /tmp/registered; echo 'runner registered'; while true; do sleep 3600; done"
       ],
       "environment": [
         { "key": "FORGEJO__database__DB_TYPE", "value": "postgres" },
@@ -73,6 +73,13 @@
       ],
       "dependsOn": {
         "forgejo": { "condition": "service_healthy" }
+      },
+      "healthCheck": {
+        "test": "test -f /tmp/registered || exit 1",
+        "interval": "5s",
+        "timeout": "3s",
+        "retries": 30,
+        "startPeriod": "5s"
       },
       "volumes": [{ "hostPath": "${APP_DATA_DIR}/data/forgejo", "containerPath": "/data" }]
     },
@@ -86,7 +93,7 @@
       ],
       "environment": [{ "key": "DOCKER_HOST", "value": "tcp://forgejo-dind:2375" }],
       "dependsOn": {
-        "forgejo-runner-register": { "condition": "service_completed_successfully" },
+        "forgejo-runner-register": { "condition": "service_healthy" },
         "forgejo-dind": { "condition": "service_started" }
       },
       "workingDir": "/data",


### PR DESCRIPTION
## Problem

Third issue in the Actions-runner chain (follows #546, #547). With `INSTALL_LOCK` fixed, `forgejo forgejo-cli actions register` now succeeds (exit 0), but the runner still never starts.

On the live server:
- `forgejo-runner-register` exits `0` (prints the runner UUID) but its restart policy is `unless-stopped`, so Docker keeps restarting it (`restarting … r10+`).
- Because it never settles into an *exited/completed* state, the `service_completed_successfully` dependency is never satisfied, and `forgejo-runner` stays in `Created` indefinitely.

The dynamic-compose schema (`apps/dynamic-compose-schema.json`) has **no per-service restart field** — Runtipi forces `restart: unless-stopped` on every service. So the one-shot init pattern is fundamentally incompatible with Runtipi.

## Fix

Redesign the init to work under `unless-stopped`:

- **register**: retry the registration until it succeeds, `touch /tmp/registered`, then hold the process open with a `sleep` loop so the container stays `Up` instead of flapping.
- add a **healthcheck** that only passes once the marker file exists.
- **forgejo-runner** now depends on `forgejo-runner-register` being `service_healthy` instead of `service_completed_successfully`.

Bump `tipi_version` 4 -> 5.

## Testing

- `make test` — 120 pass, 0 fail.
- Verified on the live server that register succeeds (exit 0) and that the only remaining blocker was the `unless-stopped` restart flap defeating `service_completed_successfully`.