### PR TITLE
fix(forgejo): give the Actions runner labels so jobs can be scheduled

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783685150475,
+  "updated_at": 1783686612259,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -89,7 +89,7 @@
       "entrypoint": "/bin/sh",
       "command": [
         "-c",
-        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); if [ ! -f /data/.runner ]; then forgejo-runner create-runner-file --instance http://forgejo:3000 --secret \"$$S\"; fi; exec forgejo-runner daemon"
+        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); if [ ! -f /data/.runner ]; then forgejo-runner create-runner-file --instance http://forgejo:3000 --secret \"$$S\"; fi; exec forgejo-runner daemon --label \"ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-22.04\" --label \"ubuntu-22.04:docker://ghcr.io/catthehacker/ubuntu:act-22.04\" --label \"docker:docker://data.forgejo.org/oci/alpine:3.20\""
       ],
       "environment": [{ "key": "DOCKER_HOST", "value": "tcp://forgejo-dind:2375" }],
       "dependsOn": {


### PR DESCRIPTION
## Problem

The Actions runner comes online but **no job can ever run**. It registered with an empty label set (`agent_labels = null`, `.runner` `labels: []`), so no workflow `runs-on:` value matches it and the scheduler never assigns work. Verified on the live server via the `action_runner` table and the runner's `.runner` file.

## Why

A runner's labels are authoritative from what it **declares on connect**. In the shared-secret flow, `create-runner-file` always writes an empty label set, so any labels set server-side at registration are overwritten to `[]`. Labels must therefore be supplied to the `daemon`.

Per the [Forgejo runner configuration docs](https://forgejo.org/docs/latest/admin/actions/configuration/): *"If it's empty when executing the `daemon`, it will use labels in the `.runner` file."* — i.e. labels passed to the daemon take precedence over the empty `.runner` file.

## Fix

Add `--label` flags to `forgejo-runner daemon` with a GitHub-compatible default set (docs recommend `catthehacker/ubuntu:act-22.04` to mimic GitHub runners):

- `ubuntu-latest` / `ubuntu-22.04` -> `ghcr.io/catthehacker/ubuntu:act-22.04`
- `docker` -> `data.forgejo.org/oci/alpine:3.20`

Bump `tipi_version` 5 -> 6.

## Testing

- `make test` — 120 pass, 0 fail.
- Post-deploy check: `action_runner.agent_labels` should be non-null and the runner should pick up a workflow with `runs-on: ubuntu-latest`.

## Sources

- https://forgejo.org/docs/latest/admin/actions/configuration/