### PR TITLE
fix(forgejo): pass runner labels via config file, not --label flags

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 6,
+  "tipi_version": 7,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783686612259,
+  "updated_at": 1783687504359,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -89,7 +89,7 @@
       "entrypoint": "/bin/sh",
       "command": [
         "-c",
-        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); if [ ! -f /data/.runner ]; then forgejo-runner create-runner-file --instance http://forgejo:3000 --secret \"$$S\"; fi; exec forgejo-runner daemon --label \"ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-22.04\" --label \"ubuntu-22.04:docker://ghcr.io/catthehacker/ubuntu:act-22.04\" --label \"docker:docker://data.forgejo.org/oci/alpine:3.20\""
+        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); if [ ! -f /data/.runner ]; then forgejo-runner create-runner-file --instance http://forgejo:3000 --secret \"$$S\"; fi; printf '%s\\n' 'runner:' '  labels:' '    - \"ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"ubuntu-22.04:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"docker:docker://data.forgejo.org/oci/alpine:3.20\"' > /data/config.yaml; exec forgejo-runner daemon --config /data/config.yaml"
       ],
       "environment": [{ "key": "DOCKER_HOST", "value": "tcp://forgejo-dind:2375" }],
       "dependsOn": {


### PR DESCRIPTION
## Problem

PR #551 broke the runner. Passing `--label` to `forgejo-runner daemon` puts it into "connection defined by program arguments" mode, which conflicts with the connection already provided by the `.runner` file (created by `create-runner-file`):

```
invalid configuration: server connection conflict between program arguments and config; only one source can provide server connections
```

The runner then restart-loops and never comes up.

## Fix

Supply the labels through a generated `config.yaml` (`runner.labels`) and start the daemon with `--config` instead of `--label`. The config file carries **no** `server.connections`, so the `.runner` file stays the single connection source (no conflict), while `runner.labels` provides the labels — which take precedence over the empty label set in `.runner`.

Same label set as before (GitHub-compatible):
- `ubuntu-latest` / `ubuntu-22.04` -> `ghcr.io/catthehacker/ubuntu:act-22.04`
- `docker` -> `data.forgejo.org/oci/alpine:3.20`

## Testing

- `make test` — 120 pass, 0 fail.
- Verified against the live runner image `data.forgejo.org/forgejo/runner:12.13.0`: `daemon --config` with a labels-only config passes connection-source validation (`Starting runner daemon`), whereas `--label` fails with the conflict above.

## Sources

- https://forgejo.org/docs/latest/admin/actions/configuration/