### PR TITLE
feat(forgejo): advertise the correct SSH clone port

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 7,
+  "tipi_version": 8,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783687504359,
+  "updated_at": 1783687887252,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -18,7 +18,8 @@
         { "key": "FORGEJO__database__PASSWD", "value": "${FORGEJO_DB_PASSWORD}" },
         { "key": "FORGEJO__security__INSTALL_LOCK", "value": "true" },
         { "key": "FORGEJO__actions__ENABLED", "value": "true" },
-        { "key": "FORGEJO__server__ROOT_URL", "value": "${APP_PROTOCOL:-http}://${APP_DOMAIN}/" }
+        { "key": "FORGEJO__server__ROOT_URL", "value": "${APP_PROTOCOL:-http}://${APP_DOMAIN}/" },
+        { "key": "FORGEJO__server__SSH_PORT", "value": "222" }
       ],
       "dependsOn": {
         "forgejo-db": { "condition": "service_healthy" }


### PR DESCRIPTION
## Context

The app maps host port `222` -> container SSH port `22`, but Forgejo was never told its public SSH port. It defaulted to `22`, so the web UI rendered SSH clone URLs as `ssh://git@<domain>:22/...` — which fail, because the host listens on `222`.

## Decision

Checked the [official runtipi-appstore forgejo](https://github.com/runtipi/runtipi-appstore/tree/master/apps/forgejo): it hardcodes `222 -> 22` with no per-port form field and no conditional inclusion (Runtipi dynamic-compose can't make a port optional). We keep that convention — port stays hardcoded at `222`, not optional and not user-configurable.

The only gap vs. correctness is the advertised port, which the official app also omits.

## Fix

Set `FORGEJO__server__SSH_PORT=222` on the main service so the UI advertises the right port. The container keeps listening on `22` internally (`SSH_LISTEN_PORT` default), and the `222 -> 22` mapping is unchanged.

Bump `tipi_version` 7 -> 8.

## Testing

- `make test` — 120 pass, 0 fail.
- Post-deploy: repo SSH clone URL in the UI should read `ssh://git@<domain>:222/...`.