### PR TITLE
fix(forgejo): set server DOMAIN so SSH clone URLs use the app domain

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 8,
+  "tipi_version": 9,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783687887252,
+  "updated_at": 1783688349239,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -18,6 +18,7 @@
         { "key": "FORGEJO__database__PASSWD", "value": "${FORGEJO_DB_PASSWORD}" },
         { "key": "FORGEJO__security__INSTALL_LOCK", "value": "true" },
         { "key": "FORGEJO__actions__ENABLED", "value": "true" },
+        { "key": "FORGEJO__server__DOMAIN", "value": "${APP_DOMAIN}" },
         { "key": "FORGEJO__server__ROOT_URL", "value": "${APP_PROTOCOL:-http}://${APP_DOMAIN}/" },
         { "key": "FORGEJO__server__SSH_PORT", "value": "222" }
       ],


### PR DESCRIPTION
ROOT_URL was set from APP_DOMAIN, so HTTP clone URLs were correct, but DOMAIN was never set and defaulted to "localhost". SSH_DOMAIN follows DOMAIN, so the UI rendered SSH clone URLs as git@localhost:222/... instead of the app's domain.

Set FORGEJO__server__DOMAIN=${APP_DOMAIN}; SSH_DOMAIN inherits it, so SSH clone URLs now use the real domain.

Bump tipi_version 8->9.