### PR TITLE
fix(forgejo): set SSH_DOMAIN explicitly so SSH clone host is the app domain

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 9,
+  "tipi_version": 10,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783688349239,
+  "updated_at": 1783688633870,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -19,6 +19,7 @@
         { "key": "FORGEJO__security__INSTALL_LOCK", "value": "true" },
         { "key": "FORGEJO__actions__ENABLED", "value": "true" },
         { "key": "FORGEJO__server__DOMAIN", "value": "${APP_DOMAIN}" },
+        { "key": "FORGEJO__server__SSH_DOMAIN", "value": "${APP_DOMAIN}" },
         { "key": "FORGEJO__server__ROOT_URL", "value": "${APP_PROTOCOL:-http}://${APP_DOMAIN}/" },
         { "key": "FORGEJO__server__SSH_PORT", "value": "222" }
       ],


### PR DESCRIPTION
## Problem

After #554 (which set `DOMAIN=${APP_DOMAIN}`), SSH clone URLs still showed `ssh://git@localhost:222/...`.

`app.ini` on the running instance:
```
DOMAIN = forgejo.<domain>      # updated correctly by #554
SSH_DOMAIN = localhost         # still stale
ROOT_URL = https://forgejo.<domain>/
```

`SSH_DOMAIN` only inherits `DOMAIN` at the **first** config generation. Once `app.ini` already contains `SSH_DOMAIN = localhost` (written by an earlier install when `DOMAIN` was still `localhost`), it persists — and Forgejo's `environment-to-ini` only overrides keys that are explicitly provided via `FORGEJO__` env vars.

## Fix

Set `FORGEJO__server__SSH_DOMAIN=${APP_DOMAIN}` explicitly, so the value is always overridden to the app domain (confirmed that `environment-to-ini` overrides existing keys — that is exactly how `DOMAIN` got corrected in #554).

Bump `tipi_version` 9 -> 10.

## Testing

- `make test` — 120 pass, 0 fail.
- Post-deploy: `app.ini` should show `SSH_DOMAIN = <app domain>` and the UI SSH clone URL should read `git@<domain>:222/...`.