### PR TITLE
fix(forgejo): run Actions job containers on host network so they resolve forgejo

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 10,
+  "tipi_version": 11,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783688633870,
+  "updated_at": 1783839230725,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -92,7 +92,7 @@
       "entrypoint": "/bin/sh",
       "command": [
         "-c",
-        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); if [ ! -f /data/.runner ]; then forgejo-runner create-runner-file --instance http://forgejo:3000 --secret \"$$S\"; fi; printf '%s\\n' 'runner:' '  labels:' '    - \"ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"ubuntu-22.04:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"docker:docker://data.forgejo.org/oci/alpine:3.20\"' > /data/config.yaml; exec forgejo-runner daemon --config /data/config.yaml"
+        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); if [ ! -f /data/.runner ]; then forgejo-runner create-runner-file --instance http://forgejo:3000 --secret \"$$S\"; fi; printf '%s\\n' 'runner:' '  labels:' '    - \"ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"ubuntu-22.04:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"docker:docker://data.forgejo.org/oci/alpine:3.20\"' 'container:' '  network: host' > /data/config.yaml; exec forgejo-runner daemon --config /data/config.yaml"
       ],
       "environment": [{ "key": "DOCKER_HOST", "value": "tcp://forgejo-dind:2375" }],
       "dependsOn": {


### PR DESCRIPTION
## Problem

Every Forgejo Actions job fails at the first step (`actions/checkout`):

```
fatal: unable to access 'http://forgejo:3000/...': Could not resolve host: forgejo
::error::The process '/usr/bin/git' failed with exit code 128
```

Actions is effectively unusable. Fixes #559.

## Root cause (DNS)

The `forgejo-runner` service writes a `config.yaml` with only `runner.labels` and **no `container` section**. With no `container.network`, the runner spawns each job on a fresh isolated per-workflow network (`WORKFLOW-*`) **inside the dind daemon**.

`forgejo` is only registered in Docker's embedded DNS on the app's user-defined network (host daemon). The job containers live in a different daemon (dind) on an ephemeral network with no `forgejo` record and no route to the app network — so `git clone http://forgejo:3000/...` can't resolve the host. The dind container itself is on the app network (that's why the runner reaches the instance), but its spawned job containers are not.

## Fix

Add `container.network: host` to the generated `config.yaml`. Job containers then share the dind container's network namespace, which is on the app network and already resolves `forgejo:3000`.

```yaml
runner:
  labels:
    - "ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-22.04"
    - "ubuntu-22.04:docker://ghcr.io/catthehacker/ubuntu:act-22.04"
    - "docker:docker://data.forgejo.org/oci/alpine:3.20"
container:
  network: host
```

Smallest change, keeps the dind design. Trade-off (acceptable for single-tenant self-hosted): less isolation between concurrent jobs, possible host-port collisions inside dind.

## Verified live (against the running dind daemon)

```console
# default per-workflow network (current behavior) -> FAILS
$ docker run --rm alpine:3.20 sh -c 'getent hosts forgejo || echo RESOLVE_FAIL'
RESOLVE_FAIL

# host networking (this fix) -> WORKS
$ docker run --rm --network host alpine:3.20 \
    sh -c 'getent hosts forgejo && wget -qO- http://forgejo:3000/api/v1/version'
10.128.11.4       forgejo  forgejo
{"version":"15.0.4+gitea-1.22.0"}
```

## Upgrade behavior

The runner rewrites `config.yaml` on every start, so updating the app (or restarting it) picks up the fix automatically — no manual edit on existing installs. Runner registration is untouched.

## Changes

- `apps/forgejo/docker-compose.json` — append `container: / network: host` to the runner's generated `config.yaml`
- `apps/forgejo/config.json` — `tipi_version` 10 → 11, `updated_at` bumped

## Validation

- `make test` — pass
- `make renovate-test` — pass (no config change needed)
