### PR TITLE
fix(forgejo): allow dind to push to the internal HTTP registry

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 11,
+  "tipi_version": 12,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783839230725,
+  "updated_at": 1783840223595,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -55,7 +55,7 @@
       "name": "forgejo-dind",
       "image": "docker:29.6.1-dind",
       "privileged": true,
-      "command": ["dockerd", "-H", "tcp://0.0.0.0:2375", "--tls=false"],
+      "command": ["dockerd", "-H", "tcp://0.0.0.0:2375", "--tls=false", "--insecure-registry", "forgejo:3000"],
       "volumes": [{ "hostPath": "${APP_DATA_DIR}/data/dind", "containerPath": "/var/lib/docker" }]
     },
     {


### PR DESCRIPTION
## Follow-up to #560

`container.network: host` (#560) fixes `actions/checkout`. Running an image-build workflow end to end surfaces a **second** required change for pushing to the built-in container registry.

## Problem

With host networking, job containers reach the registry only at the **internal** endpoint `forgejo:3000` (HTTP). The dind daemon trusts only localhost:

```
Insecure Registries:
  ::1/128
  127.0.0.0/8
```

So `docker login forgejo:3000` fails with an HTTPS-to-HTTP error, and pushes never happen. The registry is HTTP internally because TLS is terminated by the external reverse proxy, which the runner can't reach.

## Fix

Add `--insecure-registry forgejo:3000` to the `forgejo-dind` command:

```json
"command": ["dockerd", "-H", "tcp://0.0.0.0:2375", "--tls=false", "--insecure-registry", "forgejo:3000"]
```

After this, `docker login forgejo:3000` / `docker push forgejo:3000/<owner>/<image>` work from inside jobs.

## Changes

- `apps/forgejo/docker-compose.json` — add `--insecure-registry forgejo:3000` to dind
- `apps/forgejo/config.json` — `tipi_version` 11 → 12, `updated_at` bumped

## Validation

- `make test` — 120 pass, 0 fail

Refs #559.
