### PR TITLE
fix(forgejo): let Actions push to the container registry via the external domain

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 12,
+  "tipi_version": 13,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783840223595,
+  "updated_at": 1783843077612,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -55,7 +55,16 @@
       "name": "forgejo-dind",
       "image": "docker:29.6.1-dind",
       "privileged": true,
-      "command": ["dockerd", "-H", "tcp://0.0.0.0:2375", "--tls=false", "--insecure-registry", "forgejo:3000"],
+      "command": [
+        "dockerd",
+        "-H",
+        "tcp://0.0.0.0:2375",
+        "--tls=false",
+        "--insecure-registry",
+        "forgejo:3000",
+        "--insecure-registry",
+        "${APP_DOMAIN}"
+      ],
       "volumes": [{ "hostPath": "${APP_DATA_DIR}/data/dind", "containerPath": "/var/lib/docker" }]
     },
     {
@@ -92,7 +101,7 @@
       "entrypoint": "/bin/sh",
       "command": [
         "-c",
-        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); if [ ! -f /data/.runner ]; then forgejo-runner create-runner-file --instance http://forgejo:3000 --secret \"$$S\"; fi; printf '%s\\n' 'runner:' '  labels:' '    - \"ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"ubuntu-22.04:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"docker:docker://data.forgejo.org/oci/alpine:3.20\"' 'container:' '  network: host' > /data/config.yaml; exec forgejo-runner daemon --config /data/config.yaml"
+        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); if [ ! -f /data/.runner ]; then forgejo-runner create-runner-file --instance http://forgejo:3000 --secret \"$$S\"; fi; GW=$$(ip route | awk '/^default/{print $$3; exit}'); printf '%s\\n' 'runner:' '  labels:' '    - \"ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"ubuntu-22.04:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"docker:docker://data.forgejo.org/oci/alpine:3.20\"' 'container:' '  network: host' \"  options: \\\"--add-host=${APP_DOMAIN}:$$GW\\\"\" > /data/config.yaml; exec forgejo-runner daemon --config /data/config.yaml"
       ],
       "environment": [{ "key": "DOCKER_HOST", "value": "tcp://forgejo-dind:2375" }],
       "dependsOn": {


### PR DESCRIPTION
## Follow-up to #560 / #561

`actions/checkout` (#560) and internal-registry trust (#561) work. Pushing an image to Forgejo's built-in container registry still fails at `docker login`. Fixes #562.

## Root cause

Forgejo derives the registry **token realm from `ROOT_URL`**, so the `Www-Authenticate` response always points at the external `APP_DOMAIN`, regardless of which endpoint the client hits:

```
www-authenticate: Bearer realm="https://<APP_DOMAIN>/v2/token", service="container_registry"
```

Even when a job reaches the registry via the internal `forgejo:3000` name, the auth handshake bounces to `https://<APP_DOMAIN>`, which job containers can't resolve (domain resolves only outside the server) and which has no internal TLS endpoint. So jobs must reach the registry at `APP_DOMAIN` — which the host already serves: the reverse proxy publishes `:443` and routes the domain to the registry.

## Fix — two changes in `apps/forgejo/docker-compose.json`

1. **`forgejo-dind`** — trust the domain (reverse-proxy cert isn't in the daemon trust store):
   ```json
   "--insecure-registry", "${APP_DOMAIN}"
   ```
   (kept alongside the existing `forgejo:3000`)

2. **`forgejo-runner`** generated `config.yaml` — map the domain to the app-network gateway inside each job:
   ```yaml
   container:
     network: host
     options: "--add-host=${APP_DOMAIN}:<gateway>"
   ```
   The gateway is computed at runtime from the runner's default route (`GW=$(ip route | awk '/^default/{print $3; exit}')`) — same app network as dind, so **no IP is hardcoded**. Jobs inherit the dind container's `/etc/hosts` under host networking, so this one entry reaches every job; the gateway forwards `:443` to the reverse proxy.

Docker's `host-gateway` magic value can't be used here: it resolves to the default bridge (`172.17.0.1`), which is unreachable from dind on the app network.

## Verified live (against the running app)

- Domain→gateway reaches the registry: `curl --resolve <domain>:443:10.128.11.1 https://<domain>/v2/` → `401` + external realm.
- Host-network jobs inherit the dind container's `/etc/hosts` (a test entry resolved without `--add-host`).
- `host-gateway` resolves to `172.17.0.1` (default bridge) — not reachable from the app network; confirms the explicit gateway is required.
- Runner has `ip`/`awk`; the default-route gateway is `10.128.11.1` (app network gateway).

## Workflow side

Workflows must target `REGISTRY=<APP_DOMAIN>` (the external domain) for login/push.

## Changes

- `apps/forgejo/docker-compose.json` — `--insecure-registry ${APP_DOMAIN}` on dind; `--add-host` (computed gateway) in the runner's generated `config.yaml`
- `apps/forgejo/config.json` — `tipi_version` 12 → 13, `updated_at` bumped

## Validation

- `make test` — 120 pass, 0 fail

Fixes #562.
