### PR TITLE
fix(forgejo): give Actions jobs a Docker daemon and resolve the registry daemon-side

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 13,
+  "tipi_version": 14,
   "version": "15.0.4",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job. This package ships Forgejo Actions enabled with a self-hosted runner that auto-registers on first boot (Docker-in-Docker executor), giving you built-in CI/CD without any manual setup.",
@@ -29,6 +29,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1783617055000,
-  "updated_at": 1783843077612,
+  "updated_at": 1783881417735,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -55,15 +55,9 @@
       "name": "forgejo-dind",
       "image": "docker:29.6.1-dind",
       "privileged": true,
+      "entrypoint": ["/bin/sh", "-c"],
       "command": [
-        "dockerd",
-        "-H",
-        "tcp://0.0.0.0:2375",
-        "--tls=false",
-        "--insecure-registry",
-        "forgejo:3000",
-        "--insecure-registry",
-        "${APP_DOMAIN}"
+        "GW=$$(ip route | awk '/^default/{print $$3; exit}'); echo \"$$GW ${APP_DOMAIN}\" >> /etc/hosts; exec dockerd-entrypoint.sh dockerd -H tcp://0.0.0.0:2375 --tls=false --insecure-registry forgejo:3000 --insecure-registry ${APP_DOMAIN}"
       ],
       "volumes": [{ "hostPath": "${APP_DATA_DIR}/data/dind", "containerPath": "/var/lib/docker" }]
     },
@@ -101,7 +95,7 @@
       "entrypoint": "/bin/sh",
       "command": [
         "-c",
-        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); if [ ! -f /data/.runner ]; then forgejo-runner create-runner-file --instance http://forgejo:3000 --secret \"$$S\"; fi; GW=$$(ip route | awk '/^default/{print $$3; exit}'); printf '%s\\n' 'runner:' '  labels:' '    - \"ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"ubuntu-22.04:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"docker:docker://data.forgejo.org/oci/alpine:3.20\"' 'container:' '  network: host' \"  options: \\\"--add-host=${APP_DOMAIN}:$$GW\\\"\" > /data/config.yaml; exec forgejo-runner daemon --config /data/config.yaml"
+        "S=$$(printf '%s' \"${FORGEJO_RUNNER_SECRET}\" | sha1sum | cut -c1-40); if [ ! -f /data/.runner ]; then forgejo-runner create-runner-file --instance http://forgejo:3000 --secret \"$$S\"; fi; printf '%s\\n' 'runner:' '  envs:' '    DOCKER_HOST: tcp://localhost:2375' '  labels:' '    - \"ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"ubuntu-22.04:docker://ghcr.io/catthehacker/ubuntu:act-22.04\"' '    - \"docker:docker://data.forgejo.org/oci/alpine:3.20\"' 'container:' '  network: host' > /data/config.yaml; exec forgejo-runner daemon --config /data/config.yaml"
       ],
       "environment": [{ "key": "DOCKER_HOST", "value": "tcp://forgejo-dind:2375" }],
       "dependsOn": {


### PR DESCRIPTION
## Refines the registry-push fix (#562 / #563)

Debugging a real job showed the earlier fix was aimed at the wrong layer. Root cause is bigger than TLS: **job containers get no Docker daemon**.

Inside a job:
```
DOCKER_HOST=<unset>
docker version -> failed to connect to unix:///var/run/docker.sock: no such file or directory
```

So `docker build` / `login` / `push` can't run at all; the reverse-proxy cert error was just Docker 29's client-side fallback. The runner `--add-host` added in #563 never mattered — the registry connection happens on the **dind daemon**, not in the job container.

## Fix — two changes in `apps/forgejo/docker-compose.json`

1. **`forgejo-runner`** — inject `DOCKER_HOST` into every job via `runner.envs` (official runner mechanism), so workflows don't have to:
   ```yaml
   runner:
     envs:
       DOCKER_HOST: tcp://localhost:2375
   ```
   Under `container.network: host` the job shares the dind network namespace, so the daemon is reachable at `localhost:2375`. Dropped the job `--add-host` and the gateway calc from #563.

2. **`forgejo-dind`** — resolve `APP_DOMAIN` **daemon-side** (the token realm is always the external domain, whatever endpoint the client hits) and keep `--insecure-registry ${APP_DOMAIN}`. The daemon performs the registry connection, so the entry must be in the dind container's own `/etc/hosts`:
   ```sh
   GW=$(ip route | awk '/^default/{print $3; exit}')
   echo "$GW ${APP_DOMAIN}" >> /etc/hosts
   exec dockerd-entrypoint.sh dockerd ... --insecure-registry ${APP_DOMAIN}
   ```
   Gateway computed at runtime (no hardcoded IP). `host-gateway` is unusable: inside dind it resolves to dind's own `docker0` (`172.17.0.1`), not the host. Wrapped through `dockerd-entrypoint.sh` so the daemon's normal setup is preserved.

Flow: job runs `docker push` → talks to dind daemon (`localhost:2375`) → daemon resolves `APP_DOMAIN` to the gateway → reverse proxy on `:443` routes to the registry.

## Verified live (against the running app)

- Job (host-net) with `DOCKER_HOST=tcp://localhost:2375` → `docker version` returns Server `29.6.1` (daemon reachable).
- Ephemeral dind container on the app network: `ip route` gateway = `10.128.11.1`; the wrapper writes `/etc/hosts` and `APP_DOMAIN` resolves to it; `dockerd-entrypoint.sh` present.
- dind → gateway reaches the registry: `401` + external realm.
- `runner.envs` confirmed in the forgejo-runner example config as "extra environment variables to run jobs".

## Changes

- `apps/forgejo/docker-compose.json` — `runner.envs.DOCKER_HOST`; dind wrapper resolving `APP_DOMAIN` daemon-side
- `apps/forgejo/config.json` — `tipi_version` 13 → 14, `updated_at` bumped

## Validation

- `make test` — 120 pass, 0 fail

Refs #562.
